### PR TITLE
make sign and verify async

### DIFF
--- a/src/offchainapi/asyncnet.py
+++ b/src/offchainapi/asyncnet.py
@@ -88,7 +88,7 @@ class Aionet:
                     other = channel.get_other_address()
 
                     # Retransmit a few of the requests here.
-                    messages = channel.package_retransmit(number=100)
+                    messages = await channel.package_retransmit(number=100)
                     for message in messages:
                         logger.info(
                             f'Attempt to re-transmit messages {message}.'
@@ -181,7 +181,7 @@ class Aionet:
 
             # TODO: Handle timeout errors here.
             logger.debug(f'Data Received from {other_addr.as_str()}.')
-            response = channel.parse_handle_request(request_json)
+            response = await channel.parse_handle_request(request_json)
 
         except json.decoder.JSONDecodeError as e:
             # Raised if the request does not contain valid json.
@@ -246,7 +246,7 @@ class Aionet:
                     logger.debug(f'Json response: {json_response}')
 
                     # Wait in case the requests are sent out of order.
-                    res = channel.parse_handle_response(json_response)
+                    res = await channel.parse_handle_response(json_response)
                     logger.debug(f'Response parsed with status: {res}')
 
                     logger.debug(f'Process Waiting messages')
@@ -263,7 +263,7 @@ class Aionet:
             logger.debug(f'ClientError {type(e)}: {e}')
             raise NetworkException(e)
 
-    def sequence_command(self, other_addr, command):
+    async def sequence_command(self, other_addr, command):
         ''' Sequences a new command to the local queue, ready to be
             sent to the other VASP.
 
@@ -276,7 +276,7 @@ class Aionet:
 
         channel = self.vasp.get_channel(other_addr)
         request = channel.sequence_command_local(command)
-        request = channel.package_request(request)
+        request = await channel.package_request(request)
         request = request.content
         return request
 

--- a/src/offchainapi/business.py
+++ b/src/offchainapi/business.py
@@ -309,7 +309,7 @@ class VASPInfo:
         """
         raise NotImplementedError()  # pragma: no cover
 
-    def get_peer_compliance_signature_key(self, my_addr):
+    def get_my_compliance_signature_key(self, my_addr):
         """ Returns the compliance signature (secret) key of the VASP.
 
         Args:

--- a/src/offchainapi/core.py
+++ b/src/offchainapi/core.py
@@ -166,7 +166,7 @@ class Vasp:
             Note that the automatic retransmission will eventually re-sent
             the request until progress is made.
             '''
-        req = self.net_handler.sequence_command(addr, cmd)
+        req = await self.net_handler.sequence_command(addr, cmd)
         try:
             return await self.net_handler.send_request(addr, req)
         except NetworkException:

--- a/src/offchainapi/crypto.py
+++ b/src/offchainapi/crypto.py
@@ -71,13 +71,13 @@ class ComplianceKey:
     def export_full(self):
         return self._key.export_private()
 
-    def sign_message(self, payload):
+    async def sign_message(self, payload):
         signer = jws.JWS(payload.encode('utf-8'))
         signer.add_signature(self._key, alg='EdDSA')
         sig = signer.serialize(compact=True)
         return sig
 
-    def verify_message(self, signature):
+    async def verify_message(self, signature):
         try:
             verifier = jws.JWS()
             verifier.deserialize(signature)

--- a/src/offchainapi/payment_logic.py
+++ b/src/offchainapi/payment_logic.py
@@ -230,7 +230,7 @@ class PaymentProcessor(CommandProcessor):
                     # write the next request & free th obligation
                     # Or none of the two.
                     with self.storage_factory.atomic_writes():
-                        request = self.net.sequence_command(
+                        request = await self.net.sequence_command(
                             other_address, new_cmd
                         )
 

--- a/src/offchainapi/protocol.py
+++ b/src/offchainapi/protocol.py
@@ -15,6 +15,8 @@ from collections import namedtuple
 from threading import RLock
 import logging
 from itertools import islice
+import asyncio
+
 
 """ A Class to store messages meant to be sent on a network. """
 NetMessage = namedtuple('NetMessage', ['src', 'dst', 'type', 'content'])
@@ -231,7 +233,7 @@ class VASPPairChannel:
         """
         return self.command_sequence
 
-    def package_request(self, request):
+    async def package_request(self, request):
         """ A hook to send a request to other VASP.
 
         Args:
@@ -244,10 +246,10 @@ class VASPPairChannel:
 
         # Make signature.
         vasp = self.get_vasp()
-        my_key = vasp.info_context.get_peer_compliance_signature_key(
+        my_key = vasp.info_context.get_my_compliance_signature_key(
             self.get_my_address().as_str()
         )
-        json_string = my_key.sign_message(json.dumps(json_dict))
+        json_string = await my_key.sign_message(json.dumps(json_dict))
 
         net_message = NetMessage(
             self.myself,
@@ -258,7 +260,7 @@ class VASPPairChannel:
 
         return net_message
 
-    def package_response(self, response):
+    async def package_response(self, response):
         """ A hook to send a response to other VASP.
 
         Args:
@@ -271,10 +273,10 @@ class VASPPairChannel:
 
         # Sign response
         info_context = self.get_vasp().info_context
-        my_key = info_context.get_peer_compliance_signature_key(
+        my_key = info_context.get_my_compliance_signature_key(
             self.get_my_address().as_str()
         )
-        signed_response = my_key.sign_message(json.dumps(struct))
+        signed_response = await my_key.sign_message(json.dumps(struct))
 
         net_message = NetMessage(
             self.myself, self.other, CommandResponseObject, signed_response
@@ -388,7 +390,7 @@ class VASPPairChannel:
         # for an asyncronous implementation.
         return request
 
-    def parse_handle_request(self, json_command):
+    async def parse_handle_request(self, json_command):
         """ Handles a request provided as a json string or dict.
 
         Args:
@@ -403,7 +405,8 @@ class VASPPairChannel:
             other_key = vasp.info_context.get_peer_compliance_verification_key(
                 self.other_address_str
             )
-            request = json.loads(other_key.verify_message(json_command))
+            message = await other_key.verify_message(json_command)
+            request = json.loads(message)
 
             # Parse the request whoever necessary.
             request = CommandRequestObject.from_json_data_dict(
@@ -439,7 +442,7 @@ class VASPPairChannel:
             raise e
 
         # Prepare the response.
-        full_response = self.package_response(response)
+        full_response = await self.package_response(response)
         return full_response
 
     def handle_request(self, request):
@@ -569,7 +572,7 @@ class VASPPairChannel:
                 if dv in self.object_locks and self.object_locks[dv] == request.cid:
                     self.object_locks[dv] = 'True'
 
-    def parse_handle_response(self, json_response):
+    async def parse_handle_response(self, json_response):
         """ Handles a response as json string or dict.
 
         Args:
@@ -583,7 +586,8 @@ class VASPPairChannel:
             other_key = vasp.info_context.get_peer_compliance_verification_key(
                 self.other_address_str
             )
-            response = json.loads(other_key.verify_message(json_response))
+            message = await other_key.verify_message(json_response)
+            response = json.loads(message)
             response = CommandResponseObject.from_json_data_dict(
                 response, JSONFlag.NET
             )
@@ -678,12 +682,16 @@ class VASPPairChannel:
             net_messages += [request_to_send]
         return net_messages
 
-    def package_retransmit(self, number=1):
+    async def package_retransmit(self, number=1):
         """ Packages up to a `number` (int) of earlier requests without a
         reply to send to the the  other party. Returns a list of `NetMessage`
         instances.
         """
-        return [self.package_request(m) for m in self.get_retransmit(number)]
+        return await asyncio.gather(
+            *[
+                self.package_request(m) for m in self.get_retransmit(number)
+            ]
+        )
 
     def would_retransmit(self):
         """ Returns true if there are any pending re-transmits, namely

--- a/src/offchainapi/sample/sample_service.py
+++ b/src/offchainapi/sample/sample_service.py
@@ -50,7 +50,7 @@ class sample_vasp_info(VASPInfo):
         assert not self.other_key._key.has_private
         return self.other_key
 
-    def get_peer_compliance_signature_key(self, my_addr):
+    def get_my_compliance_signature_key(self, my_addr):
         return self.my_key
 
 
@@ -247,10 +247,10 @@ class sample_vasp:
         channel = self.vasp.get_channel(other_vasp)
         return channel
 
-    def process_request(self, other_vasp, request_json):
+    async def process_request(self, other_vasp, request_json):
         # Get the channel
         channel = self.get_channel(other_vasp)
-        resp = channel.parse_handle_request(request_json)
+        resp = await channel.parse_handle_request(request_json)
         return resp
 
     def insert_local_command(self, other_vasp, command):
@@ -258,10 +258,10 @@ class sample_vasp:
         req = channel.sequence_command_local(command)
         return req
 
-    def process_response(self, other_vasp, response_json):
+    async def process_response(self, other_vasp, response_json):
         channel = self.get_channel(other_vasp)
         try:
-            channel.parse_handle_response(response_json)
+            await channel.parse_handle_response(response_json)
         except OffChainProtocolError:
             pass
         except OffChainException:

--- a/src/offchainapi/tests/conftest.py
+++ b/src/offchainapi/tests/conftest.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock
 from mock import AsyncMock
 import pytest
 import json
+import asyncio
 
 
 @pytest.fixture
@@ -84,7 +85,7 @@ def vasp(three_addresses, store, key):
     command_processor = MagicMock(spec=CommandProcessor)
     info_context = MagicMock(spec=VASPInfo)
     info_context.get_peer_compliance_verification_key.return_value = key
-    info_context.get_peer_compliance_signature_key.return_value = key
+    info_context.get_my_compliance_signature_key.return_value = key
     return OffChainVASP(a0, command_processor, store, info_context)
 
 
@@ -140,8 +141,8 @@ def json_response():
 
 @pytest.fixture
 def signed_json_request(json_request, key):
-    return key.sign_message(json.dumps(json_request))
+    return asyncio.run(key.sign_message(json.dumps(json_request)))
 
 @pytest.fixture
 def signed_json_response(json_response, key):
-    return key.sign_message(json.dumps(json_response))
+    return asyncio.run(key.sign_message(json.dumps(json_response)))

--- a/src/offchainapi/tests/local_benchmark.py
+++ b/src/offchainapi/tests/local_benchmark.py
@@ -48,7 +48,7 @@ class SimpleVASPInfo(VASPInfo):
         assert not key._key.has_private
         return key
 
-    def get_peer_compliance_signature_key(self, my_addr):
+    def get_my_compliance_signature_key(self, my_addr):
         return peer_keys[my_addr]
 
     def is_authorised_VASP(self, certificate, other_addr):

--- a/src/offchainapi/tests/remote_benchmark.py
+++ b/src/offchainapi/tests/remote_benchmark.py
@@ -47,7 +47,7 @@ class SimpleVASPInfo(VASPInfo):
     def get_peer_compliance_verification_key(self, other_addr):
         return self.other_configs['key']
 
-    def get_peer_compliance_signature_key(self, my_addr):
+    def get_my_compliance_signature_key(self, my_addr):
         return self.my_configs['key']
 
     def get_TLS_cert_path(self, other_addr):

--- a/src/offchainapi/tests/test_crypto.py
+++ b/src/offchainapi/tests/test_crypto.py
@@ -83,19 +83,21 @@ def test_export_import():
     assert key == key_full
 
 
-def test_sign_verif_correct():
+async def test_sign_verif_correct():
     key = ComplianceKey.generate()
-    sig = key.sign_message(payload = 'Hello World!')
-    assert key.verify_message(sig) == 'Hello World!'
+    sig = await key.sign_message(payload = 'Hello World!')
+    raw = await key.verify_message(sig)
+    assert raw == "Hello World!"
 
 
-def test_sign_verif_incorrect():
+async def test_sign_verif_incorrect():
     key = ComplianceKey.generate()
-    sig = key.sign_message(payload = 'Hello World!')
+    sig = await key.sign_message(payload = 'Hello World!')
 
     key2 = ComplianceKey.generate()
     with pytest.raises(OffChainInvalidSignature):
-        assert key2.verify_message(sig) == 'Hello World!'
+        sig = await key2.verify_message(sig)
+        assert sig == 'Hello World!'
 
 
 def test_encode_recipient():

--- a/src/offchainapi/tests/test_protocol.py
+++ b/src/offchainapi/tests/test_protocol.py
@@ -564,8 +564,8 @@ def test_sample_command():
 
 
 async def test_parse_handle_request_to_future(signed_json_request, channel, key):
-    fut = await channel.parse_handle_request(signed_json_request)
-    res = await key.verify_message(fut.content)
+    response = await channel.parse_handle_request(signed_json_request)
+    res = await key.verify_message(response.content)
 
     res = json.loads(res)
     assert res['status'] == 'success'

--- a/src/offchainapi/tests/test_protocol.py
+++ b/src/offchainapi/tests/test_protocol.py
@@ -14,8 +14,8 @@ from copy import deepcopy
 import random
 from unittest.mock import MagicMock
 import pytest
-import asyncio
 import json
+
 
 class RandomRun(object):
     def __init__(self, server, client, commands, seed='fixed seed'):
@@ -314,65 +314,58 @@ def test_protocol_server_client_interleaved_swapped_request(two_channels):
     assert {c.command.item() for c in server.get_final_sequence()} == {
         'World', 'Hello'}
 
-def test_protocol_conflict1(two_channels):
+async def test_protocol_conflict1(two_channels):
     server, client = two_channels
 
     msg = client.sequence_command_local(SampleCommand('Hello'))
-    msg = client.package_request(msg).content
+    msg = (await client.package_request(msg)).content
 
-    msg2 = server.parse_handle_request(msg).content
+    msg2 = (await server.parse_handle_request(msg)).content
 
     # Since this is not yet confirmed, reject the command
     with pytest.raises(DependencyException):
         client.sequence_command_local(SampleCommand('World1', deps=['Hello']))
 
     msg3 = server.sequence_command_local(SampleCommand('World2', deps=['Hello']))
-    msg3 = server.package_request(msg3).content
+    msg3 = (await server.package_request(msg3)).content
 
     # Since this is not yet confirmed, reject the command
-    msg4 = client.parse_handle_request(msg3).content
-    succ = server.parse_handle_response(msg4)
-    assert not succ  # Fails
+    msg4 = (await client.parse_handle_request(msg3)).content
+    assert not await server.parse_handle_response(msg4)  # Fails
 
     # Now add the response that creates 'hello'
-    succ = client.parse_handle_response(msg2)
-    assert succ  # success
+    assert await client.parse_handle_response(msg2)  # success
 
-
-def test_protocol_conflict2(two_channels):
+async def test_protocol_conflict2(two_channels):
     server, client = two_channels
 
     msg = client.sequence_command_local(SampleCommand('Hello'))
-    msg = client.package_request(msg).content
+    msg = (await client.package_request(msg)).content
 
-    msg2 = server.parse_handle_request(msg).content
-    succ = client.parse_handle_response(msg2)
-    assert succ  # success
+    msg2 = (await server.parse_handle_request(msg)).content
+    assert await client.parse_handle_response(msg2)  # success
 
     # Two concurrent requests
     creq = client.sequence_command_local(SampleCommand('cW', deps=['Hello']))
-    creq = client.package_request(creq).content
+    creq = (await client.package_request(creq)).content
     sreq = server.sequence_command_local(SampleCommand('sW', deps=['Hello']))
-    sreq = server.package_request(sreq).content
+    sreq = (await server.package_request(sreq)).content
 
     # Server gets client request
-    sresp = server.parse_handle_request(creq).content
+    sresp = (await server.parse_handle_request(creq)).content
     # Client is told to wait
     with pytest.raises(OffChainProtocolError):
-        _ = client.parse_handle_response(sresp)
+        _ = await client.parse_handle_response(sresp)
 
     # Client gets server request
-    cresp = client.parse_handle_request(sreq).content
-    succ = server.parse_handle_response(cresp)
-    assert succ  # Success
-
+    cresp = (await client.parse_handle_request(sreq)).content
+    assert await server.parse_handle_response(cresp)  # Success
     assert 'Hello' in server.object_locks
     assert server.object_locks['Hello'] == 'False'
 
     # Now try again the client request
-    sresp = server.parse_handle_request(creq).content
-    succ = client.parse_handle_response(sresp)
-    assert not succ
+    sresp = (await server.parse_handle_request(creq)).content
+    assert not await client.parse_handle_response(sresp)
 
 
 
@@ -570,40 +563,39 @@ def test_sample_command():
     assert obj2.previous_versions == obj.previous_versions
 
 
-def test_parse_handle_request_to_future(signed_json_request, channel, key):
-    fut = channel.parse_handle_request(
-        signed_json_request)
-    res = fut.content
-    res = json.loads(key.verify_message(res))
+async def test_parse_handle_request_to_future(signed_json_request, channel, key):
+    fut = await channel.parse_handle_request(signed_json_request)
+    res = await key.verify_message(fut.content)
+
+    res = json.loads(res)
     assert res['status'] == 'success'
 
 
-def test_parse_handle_request_to_future_out_of_order(json_request, channel,
-                                                     key):
+async def test_parse_handle_request_to_future_out_of_order(
+    json_request, channel, key
+):
     json_request['cid'] = '100'
-    json_request = key.sign_message(json.dumps(json_request))
-    fut = channel.parse_handle_request(
-        json_request
-    )
-    res = fut.content
-    res = json.loads(key.verify_message(res))
+    json_request = await key.sign_message(json.dumps(json_request))
+    fut = await channel.parse_handle_request(json_request)
+    res = await key.verify_message(fut.content)
+    res = json.loads(res)
     assert res['status']== 'success'
 
 
-def test_parse_handle_request_to_future_exception(json_request, channel):
+async def test_parse_handle_request_to_future_exception(json_request, channel):
     with pytest.raises(Exception):
-        fut = channel.parse_handle_request(
+        fut = await channel.parse_handle_request(
             json_request  # json_request is not signed.
         )
 
 
-def test_parse_handle_response_to_future_parsing_error(json_response, channel,
+async def test_parse_handle_response_to_future_parsing_error(json_response, channel,
                                                        command, key):
     _ = channel.sequence_command_local(command)
     json_response['cid'] = '"'  # Trigger a parsing error.
-    json_response = key.sign_message(json.dumps(json_response))
+    json_response = await key.sign_message(json.dumps(json_response))
     with pytest.raises(Exception):
-        _ = channel.parse_handle_response(json_response)
+        _ = await channel.parse_handle_response(json_response)
 
 
 def test_get_storage_factory(vasp):


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.
-->

## Motivation

This PR is to make `verify_message` and `sign_message` (and or their transitive callers) async.  

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

tox

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/off-chain-reference, and link to your PR here.)
