### PR TITLE
use libra sdk for dual attestation encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setuptools.setup(
         'aiohttp',
         'bech32',
         'jwcrypto',
+        'libra-client-sdk',
     ],
     version="0.0.1.dev1",
 )

--- a/src/offchainapi/crypto.py
+++ b/src/offchainapi/crypto.py
@@ -125,7 +125,7 @@ class ComplianceKey:
                amount (int): a unsigned integer of transaction amount
                signature (bytes): ed25519 signature bytes
             Returns none when verification succeeds.
-            Raises InvalidSignature when verification fails.
+            Raises OffChainInvalidSignature when verification fails.
         """
         address = utils.account_address(bytes.hex(libra_address_bytes))
         _, dual_attestation_msg = txnmetadata.travel_rule(reference_id, address, amount)

--- a/src/offchainapi/tests/test_crypto.py
+++ b/src/offchainapi/tests/test_crypto.py
@@ -3,8 +3,7 @@
 
 from jwcrypto import jwk, jws
 import json
-from ..crypto import ComplianceKey, OffChainInvalidSignature, \
-    encode_ref_id_data
+from ..crypto import ComplianceKey, OffChainInvalidSignature
 import pytest
 
 def test_init():
@@ -100,92 +99,41 @@ async def test_sign_verif_incorrect():
         assert sig == 'Hello World!'
 
 
-def test_encode_recipient():
-
-    META_DATA_BYTES = [0x61, 0x1e, 0x0,  0x0,  0x0, 0x0,  0x0, 0x0]
-    LIBRA_ADDRESS = [
-            0x65, 0xe9, 0xe9, 0xd3, 0x6, 0x3b, 0xbb,  0x14,
-            0x31, 0xb3, 0xb6, 0x55, 0xc8, 0x1e, 0x2b, 0x7b,
-        ]
-    VALUE_BYTES = [0x40, 0x42, 0xf,  0x0,  0x0,  0x0,  0x0,  0x0, ]
-    SEPARATOR = [
-            0x40, 0x40, 0x24, 0x24, 0x4c, 0x49, 0x42, 0x52,
-            0x41, 0x5f, 0x41, 0x54, 0x54, 0x45, 0x53, 0x54,
-            0x24, 0x24, 0x40, 0x40]
-
-    MSG = META_DATA_BYTES + LIBRA_ADDRESS + VALUE_BYTES + SEPARATOR
-
-    SIG = [ 0x2b, 0x37, 0xea, 0xe2, 0xea, 0xb9, 0x4f,  0x1,
-            0x8e, 0x82, 0x39,  0x1, 0xd8, 0x6e, 0x99, 0x23,
-            0xaa, 0x4d, 0xbb, 0x31, 0x29, 0xc2, 0xc3, 0x86,
-            0x8a, 0x5f, 0x27, 0xc5, 0x96, 0xd4, 0xa4, 0x99,
-            0x3e, 0x36, 0xd2, 0xc6, 0xfd, 0x93, 0xa6, 0xe8,
-            0xe8, 0x8a, 0x7a, 0x88, 0x22, 0xb8, 0x94, 0xb4,
-            0xaa, 0xc3, 0xa3, 0x28,  0xc, 0x26, 0xdf, 0x1d,
-            0x48, 0x60, 0x70, 0x4f, 0x71, 0xc6, 0xa4,  0x2 ]
-
-    PUB = [ 0xe1, 0x4c, 0x7d, 0xdb, 0x77, 0x13, 0xc9, 0xc7,
-            0x31, 0x5f, 0x33, 0x73, 0x93, 0xf4, 0x26, 0x1d,
-            0x17, 0x13, 0xa5, 0xf8, 0xc6, 0xc6, 0xe1, 0x4c,
-            0x49, 0x86, 0xe6, 0x16, 0x46, 0x2,  0x51, 0xe6 ]
-
-    msg_b = bytes(MSG)
-    sig_b = bytes(SIG)
-    pub_b = bytes(PUB)
-
-    assert len(MSG) == 52
-    assert len(sig_b) == 64
-    assert len(pub_b) == 32
-
-    # First try verification
-    from cryptography.hazmat.primitives.asymmetric.ed25519 \
-        import Ed25519PublicKey
-
-    pub = Ed25519PublicKey.from_public_bytes(pub_b)
-    pub.verify(sig_b, msg_b)
-
-    # Check the encoding is the same
-    enc = encode_ref_id_data(
-        bytes([0x61, 0x1e, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0]),
-        bytes([0x65, 0xe9, 0xe9, 0xd3, 0x6, 0x3b, 0xbb, 0x14,
-               0x31, 0xb3, 0xb6, 0x55, 0xc8, 0x1e, 0x2b, 0x7b]),
-        1_000_000
-    )
-    assert enc == msg_b
-
-    # Now check the same using our own ComplianceKey abstraction
-    ck = ComplianceKey.from_pub_bytes(pub_b)
-    ck.verify_ref_id(
-        bytes([0x61, 0x1e, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0]),
-        bytes([0x65, 0xe9, 0xe9, 0xd3, 0x6, 0x3b, 0xbb, 0x14,
-               0x31, 0xb3, 0xb6, 0x55, 0xc8, 0x1e, 0x2b, 0x7b]),
-        1_000_000,
-        sig_b.hex()
-    )
-
-
-def test_example_ref_id_sign_verify():
-    # Generate and export keys
+def test_dual_attestation_signing_and_verifying():
     key = ComplianceKey.generate()
+    addr_bytes = bytes.fromhex("f72589b71ff4f8d139674a3f7369c69b")
+    reference_id = "reference_id"
+    amount = 5_555_555
+    dual_attestation_signature = key.sign_dual_attestation_data(
+        reference_id,
+        addr_bytes,
+        amount,
+    )
 
-    meta = bytes([0x61, 0x1e, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0])
-    addr = bytes([0x65, 0xe9, 0xe9, 0xd3, 0x6, 0x3b, 0xbb, 0x14,
-                  0x31, 0xb3, 0xb6, 0x55, 0xc8, 0x1e, 0x2b, 0x7b])
-    value = 1_000_000
+    key.verify_dual_attestation_data(
+        reference_id,
+        addr_bytes,
+        amount,
+        dual_attestation_signature,
+    )
 
     # Invalid length
     with pytest.raises(Exception):
-        sign = key.sign_ref_id(meta, addr+b'A', value)
+        dual_attestation_signature = key.sign_dual_attestation_data(
+            reference_id,
+            addr_bytes+b'A',
+            amount
+        )
 
-    sign = key.sign_ref_id(meta, addr, value)
-    key.verify_ref_id(meta, addr, value, sign)
-
-
-    # Invalid value
+    # Invalid amount
     with pytest.raises(OffChainInvalidSignature):
-        key.verify_ref_id(meta, addr, value-1, sign)
+        key.verify_dual_attestation_data(reference_id, addr_bytes, amount-1, dual_attestation_signature)
 
     # Invalid address
-    addr_bad = bytes([0x00]) + addr[1:]
     with pytest.raises(OffChainInvalidSignature):
-        key.verify_ref_id(meta, addr_bad, value, sign)
+        key.verify_dual_attestation_data(
+            reference_id,
+            bytes.fromhex("fffffffffffffffff9674a3f7369c69b"),
+            amount,
+            dual_attestation_signature
+        )


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.
-->

## Motivation

use libra sdk for dual attestation encoding

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

tox and tested in testnet 

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/off-chain-reference, and link to your PR here.)
