### PR TITLE
handle KeyError resulted from `new_version`

### DIFF
--- a/src/offchainapi/payment_logic.py
+++ b/src/offchainapi/payment_logic.py
@@ -821,6 +821,7 @@ class PaymentProcessor(CommandProcessor):
                 f'SENDER={is_sender}'
             )
 
+        assert new_payment is not None
         new_payment.data[role].change_status(
             StatusObject(current_status, abort_code, abort_msg))
         return new_payment


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.
-->

## Motivation

`payment.new_version(store=self.object_store)` can raise `KeyError` exception when the passed in object_store does not contain the payment version (`self.version`). This change embrace this statement in the try/except block and handle the `KeyError` exception as other ordinary exceptions, resulting an abort of payment.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

tox
## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/off-chain-reference, and link to your PR here.)
