### PR TITLE
add more checks in can_change_status

### DIFF
--- a/src/offchainapi/status_logic.py
+++ b/src/offchainapi/status_logic.py
@@ -46,3 +46,14 @@ class Status(Enum):
 
     def __repr__(self):
         return self.name
+
+
+STATUS_HEIGHTS = {
+    Status.none: 100,
+    Status.needs_kyc_data: 200,
+    Status.needs_recipient_signature: 200,
+    Status.soft_match: 200,
+    Status.pending_review: 200,
+    Status.ready_for_settlement: 400,
+    Status.abort: 1000
+}

--- a/src/offchainapi/tests/test_payment_logic.py
+++ b/src/offchainapi/tests/test_payment_logic.py
@@ -460,15 +460,16 @@ def test_can_change_status(payment, loop):
     reset_payment_status(payment)
 
     # 5: one side cannot change to lower status
+    # sender action
     for old_status in Status:
         update_role_status(payment, "sender", old_status)
         for new_status in Status:
             if STATUS_HEIGHTS[new_status] < STATUS_HEIGHTS[old_status]:
-                print(f"new: {new_status}, old: {old_status}")
                 assert not processor.can_change_status(payment, new_status, actor_is_sender=True)
 
     reset_payment_status(payment)
 
+    # receiver action
     for old_status in Status:
         update_role_status(payment, "receiver", old_status)
         for new_status in Status:

--- a/src/offchainapi/tests/test_payment_logic.py
+++ b/src/offchainapi/tests/test_payment_logic.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from ..protocol import VASPPairChannel
-from ..status_logic import Status
+from ..status_logic import Status, STATUS_HEIGHTS
 from ..payment_command import PaymentCommand, PaymentLogicError
 from ..business import BusinessForceAbort, BusinessValidationFailure
 
@@ -390,3 +390,87 @@ def test_process_command_success_vanilla(payment, loop):
 
     assert [call[0] for call in net.method_calls] == [
         'sequence_command', 'send_request']
+
+
+def reset_payment_status(payment):
+    payment.sender.status = StatusObject(Status.none)
+    payment.receiver.status = StatusObject(Status.none)
+
+def update_role_status(payment, role, status):
+    if status == Status.abort:
+        payment.data[role].status = StatusObject(status, "", "")
+    else:
+        payment.data[role].status = StatusObject(status)
+
+def test_can_change_status(payment, loop):
+    """ Test invalid status change are rejected """
+    store = StorableFactory({})
+    my_addr = LibraAddress.from_bytes(b'B'*16)
+    other_addr = LibraAddress.from_bytes(b'A'*16)
+    bcm = TestBusinessContext(my_addr)
+    processor = PaymentProcessor(bcm, store, loop)
+
+    # 1: if one side is aborted, it should never switch to other status
+    # sender action
+    update_role_status(payment, "sender", Status.abort)
+    assert processor.can_change_status(payment, Status.abort, actor_is_sender=True)
+    assert not processor.can_change_status(payment, Status.ready_for_settlement, actor_is_sender=True)
+    reset_payment_status(payment)
+
+    # receiver action
+    update_role_status(payment, "receiver", Status.abort)
+    assert processor.can_change_status(payment, Status.abort, actor_is_sender=False)
+    assert not processor.can_change_status(payment, Status.ready_for_settlement, actor_is_sender=False)
+    reset_payment_status(payment)
+
+    # 2: if one side aborts, the other side cannot transit to status other than abort
+    # sender action
+    update_role_status(payment, "receiver", Status.abort)
+    assert processor.can_change_status(payment, Status.abort, actor_is_sender=True)
+    assert not processor.can_change_status(payment, Status.ready_for_settlement, actor_is_sender=True)
+    reset_payment_status(payment)
+
+    # receiver action
+    update_role_status(payment, "sender", Status.abort)
+    assert processor.can_change_status(payment, Status.abort, actor_is_sender=False)
+    assert not processor.can_change_status(payment, Status.ready_for_settlement, actor_is_sender=False)
+    reset_payment_status(payment)
+
+    # 3: if one side is ready_for_settlement, it can only switch to abort
+    # when the other side turns to abort
+    # sender action
+    update_role_status(payment, "sender", Status.ready_for_settlement)
+    update_role_status(payment, "receiver", Status.needs_kyc_data)
+    assert not processor.can_change_status(payment, Status.abort, actor_is_sender=True)
+    assert not processor.can_change_status(payment, Status.soft_match, actor_is_sender=True)
+    reset_payment_status(payment)
+
+    # receiver action
+    update_role_status(payment, "sender", Status.needs_kyc_data)
+    update_role_status(payment, "receiver", Status.ready_for_settlement)
+    assert not processor.can_change_status(payment, Status.abort, actor_is_sender=False)
+    assert not processor.can_change_status(payment, Status.needs_recipient_signature, actor_is_sender=False)
+    reset_payment_status(payment)
+
+    # 4: if both sides are ready_for_settlement, neither side can change status
+    update_role_status(payment, "sender", Status.ready_for_settlement)
+    update_role_status(payment, "receiver", Status.ready_for_settlement)
+    assert not processor.can_change_status(payment, Status.abort, actor_is_sender=True)
+    assert not processor.can_change_status(payment, Status.abort, actor_is_sender=False)
+    reset_payment_status(payment)
+
+    # 5: one side cannot change to lower status
+    for old_status in Status:
+        update_role_status(payment, "sender", old_status)
+        for new_status in Status:
+            if STATUS_HEIGHTS[new_status] < STATUS_HEIGHTS[old_status]:
+                print(f"new: {new_status}, old: {old_status}")
+                assert not processor.can_change_status(payment, new_status, actor_is_sender=True)
+
+    reset_payment_status(payment)
+
+    for old_status in Status:
+        update_role_status(payment, "receiver", old_status)
+        for new_status in Status:
+            if STATUS_HEIGHTS[new_status] < STATUS_HEIGHTS[old_status]:
+                assert not processor.can_change_status(payment, new_status, actor_is_sender=False)


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.
-->

## Motivation

NCC pointed out in their pentest results that with our current implementation, receiver can still change status (say, from none -> ready_for_settlement, when sender has aborted the payment. 
This PR adds the check in can_change_status and test cases for this function.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

tox

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/off-chain-reference, and link to your PR here.)
