### PR TITLE
allow empty subaddress and correct encoded_address_bytes to encoded_a…

### DIFF
--- a/src/offchainapi/libra_address.py
+++ b/src/offchainapi/libra_address.py
@@ -73,10 +73,10 @@ class LibraAddress:
         return cls(encoded_str, onchain_address_bytes, None, hrp)
 
 
-    def __init__(self, encoded_address_bytes, onchain_address_bytes, subaddress_bytes, hrp):
+    def __init__(self, encoded_address_str, onchain_address_bytes, subaddress_bytes, hrp):
         """ DO NOT CALL THIS DIRECTLY!! use factory methods instead."""
 
-        self.encoded_address_bytes = encoded_address_bytes
+        self.encoded_address_str = encoded_address_str
         self.onchain_address_bytes = onchain_address_bytes
         self.subaddress_bytes = subaddress_bytes
         self.hrp = hrp
@@ -88,7 +88,7 @@ class LibraAddress:
         )
 
     def as_str(self):
-        return self.encoded_address_bytes
+        return self.encoded_address_str
 
     def last_bit(self):
         """ Get the last bit of the decoded onchain Libra Blockchain address.
@@ -124,7 +124,7 @@ class LibraAddress:
         return self.equal(other)
 
     def __hash__(self):
-        return self.encoded_address_bytes.__hash__()
+        return self.encoded_address_str.__hash__()
 
     def get_onchain(self):
         """ Return a LibraAddress representing only the onchain address

--- a/src/offchainapi/payment_logic.py
+++ b/src/offchainapi/payment_logic.py
@@ -454,26 +454,12 @@ class PaymentProcessor(CommandProcessor):
         # TODO: catch exceptions into Payment errors
 
         try:
-            sub_send = LibraAddress.from_encoded_str(new_payment.sender.address)
-            sub_revr = LibraAddress.from_encoded_str(new_payment.receiver.address)
+            send_addr = LibraAddress.from_encoded_str(new_payment.sender.address)
+            receiver_addr = LibraAddress.from_encoded_str(new_payment.receiver.address)
         except LibraAddressError as e:
             raise PaymentLogicError(
                 OffChainErrorCode.payment_invalid_libra_address,
                 str(e)
-            )
-
-        # TODO: TEST and fix these
-        if not sub_send.subaddress_bytes:
-            raise PaymentLogicError(
-                OffChainErrorCode.payment_invalid_libra_subaddress,
-                f'Sender address needs to contain an encoded subaddress, '
-                f'but got {sub_send.as_str()}'
-            )
-        if not sub_revr.subaddress_bytes:
-            raise PaymentLogicError(
-                OffChainErrorCode.payment_invalid_libra_subaddress,
-                f'Receiver address needs to contain an encoded subaddress, '
-                f'but got {sub_revr.as_str()}'
             )
 
         try:

--- a/src/offchainapi/tests/test_libra_address.py
+++ b/src/offchainapi/tests/test_libra_address.py
@@ -14,13 +14,13 @@ def test_onchain_address_only_OK():
     libra_addr = LibraAddress.from_bytes(LBR, onchain_address_bytes)
     assert libra_addr.onchain_address_bytes == onchain_address_bytes
     assert libra_addr.subaddress_bytes == None
-    expected_encoded_bytes = bech32_address_encode(
+    expected_encoded_str = bech32_address_encode(
         LBR,
         onchain_address_bytes,
         None
     )
-    assert libra_addr.encoded_address_bytes == expected_encoded_bytes
-    assert libra_addr.as_str() == expected_encoded_bytes
+    assert libra_addr.encoded_address_str == expected_encoded_str
+    assert libra_addr.as_str() == expected_encoded_str
     assert libra_addr.get_onchain_address_hex() == bytes.hex(onchain_address_bytes)
     assert libra_addr.get_subaddress_hex() == None
 
@@ -32,13 +32,13 @@ def test_non_none_subaddress_OK():
     libra_addr = LibraAddress.from_bytes(LBR, onchain_address_bytes, subaddr_bytes)
     assert libra_addr.onchain_address_bytes == onchain_address_bytes
     assert libra_addr.subaddress_bytes == subaddr_bytes
-    expected_encoded_bytes = bech32_address_encode(
+    expected_encoded_str = bech32_address_encode(
         LBR,
         onchain_address_bytes,
         subaddr_bytes
     )
-    assert libra_addr.encoded_address_bytes == expected_encoded_bytes
-    assert libra_addr.as_str() == expected_encoded_bytes
+    assert libra_addr.encoded_address_str == expected_encoded_str
+    assert libra_addr.as_str() == expected_encoded_str
     assert libra_addr.get_onchain_address_hex() == bytes.hex(onchain_address_bytes)
     assert libra_addr.get_subaddress_hex() == bytes.hex(subaddr_bytes)
 
@@ -74,14 +74,14 @@ def test_from_encoded_str():
     onchain_address_bytes = uuid4().bytes
     subaddress_bytes = uuid4().bytes[8:]
     libra_addr_one = LibraAddress.from_bytes(TLB, onchain_address_bytes, subaddress_bytes)
-    libra_addr_two = LibraAddress.from_encoded_str(libra_addr_one.encoded_address_bytes)
+    libra_addr_two = LibraAddress.from_encoded_str(libra_addr_one.encoded_address_str)
     assert libra_addr_one == libra_addr_two
     assert libra_addr_two.hrp == TLB
     assert libra_addr_two.onchain_address_bytes == onchain_address_bytes
     assert libra_addr_two.subaddress_bytes == subaddress_bytes
 
     libra_addr_three = LibraAddress.from_bytes(LBR, onchain_address_bytes, None)
-    libra_addr_four = LibraAddress.from_encoded_str(libra_addr_three.encoded_address_bytes)
+    libra_addr_four = LibraAddress.from_encoded_str(libra_addr_three.encoded_address_str)
     assert libra_addr_three == libra_addr_four
     assert libra_addr_four.hrp == LBR
     assert libra_addr_four.onchain_address_bytes == onchain_address_bytes

--- a/src/offchainapi/tests/test_payment_logic.py
+++ b/src/offchainapi/tests/test_payment_logic.py
@@ -76,7 +76,7 @@ def test_bad_sender_actor_address(payment, processor):
         processor.check_new_payment(payment)
     assert e.value.error_code == OffChainErrorCode.payment_invalid_libra_address
 
-def test_bad_sender_actor_subaddress(payment, processor):
+def test_empty_sender_actor_subaddress(payment, processor):
     bcm = processor.business_context()
     bcm.is_recipient.side_effect = [False] * 4
 
@@ -84,9 +84,7 @@ def test_bad_sender_actor_subaddress(payment, processor):
     addr2 = LibraAddress.from_bytes("lbr", addr.onchain_address_bytes, None)
     payment.sender.address = addr2.as_str()
 
-    with pytest.raises(PaymentLogicError) as e:
-        processor.check_new_payment(payment)
-    assert e.value.error_code == OffChainErrorCode.payment_invalid_libra_subaddress
+    processor.check_new_payment(payment)
 
 def test_bad_receiver_actor_address(payment, processor):
     snone = StatusObject(Status.none)
@@ -100,7 +98,7 @@ def test_bad_receiver_actor_address(payment, processor):
         processor.check_new_payment(payment)
     assert e.value.error_code == OffChainErrorCode.payment_invalid_libra_address
 
-def test_bad_receiver_actor_subaddress(payment, processor):
+def test_empty_receiver_actor_subaddress(payment, processor):
     bcm = processor.business_context()
     bcm.is_recipient.side_effect = [False] * 4
 
@@ -108,9 +106,7 @@ def test_bad_receiver_actor_subaddress(payment, processor):
     addr2 = LibraAddress.from_bytes("lbr", addr.onchain_address_bytes, None)
     payment.receiver.address = addr2.as_str()
 
-    with pytest.raises(PaymentLogicError) as e:
-        processor.check_new_payment(payment)
-    assert e.value.error_code == OffChainErrorCode.payment_invalid_libra_subaddress
+    processor.check_new_payment(payment)
 
 def test_payment_update_from_sender(payment, processor):
     bcm = processor.business_context()


### PR DESCRIPTION

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.
-->

## Motivation
Today we don't allow the LibraAddress in PaymentActor to have empty subaddress. I think this does not hold for coin purchase (especially for designated dealer) where subaddress is unimportant. Hence I propose to move the enforcement for subaddress and delegate the check to users (VASPs/DDs), so they can do whatever they want for a payment. 

In this PR I also renamed a few variables for clarification.

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

tox

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/off-chain-reference, and link to your PR here.)
