### PR TITLE
Use different url join

### DIFF
--- a/src/offchainapi/asyncnet.py
+++ b/src/offchainapi/asyncnet.py
@@ -5,12 +5,11 @@ from .business import BusinessNotAuthorized
 from .libra_address import LibraAddress
 from .utils import get_unique_string
 
-import aiohttp
+import aiohttp, os
 from aiohttp import web
 from aiohttp.client_exceptions import ClientError
 import asyncio
 import logging
-from urllib.parse import urljoin
 
 
 logger = logging.getLogger(name='libra_off_chain_api.asyncnet')
@@ -128,7 +127,7 @@ class Aionet:
             server = self.vasp.get_vasp_address().as_str()
             client = other_addr_str
         url = f'v1/{server}/{client}/command/'
-        full_url = urljoin(base_url, url)
+        full_url = '/'.join([base_url.rstrip('/'), url])
         return full_url
 
 

--- a/src/offchainapi/tests/test_asyncnet.py
+++ b/src/offchainapi/tests/test_asyncnet.py
@@ -138,3 +138,25 @@ async def test_watchdog_task(net_handler, tester_addr, server, command):
     waiting_packages = await channel.package_retransmit(number=100)
     assert not waiting_packages
     await net_handler.close()
+
+
+def test_get_url(net_handler, tester_addr, testee_addr):
+    base_url = "http://offchain.test.com/offchain"
+    expected = f"{base_url}/v1/{tester_addr.as_str()}/{testee_addr.as_str()}/command/"
+    url = net_handler.get_url(base_url, tester_addr.as_str(), other_is_server=True)
+    assert url == expected
+
+    base_url = "http://offchain.test.com/offchain/"
+    expected = f"{base_url}v1/{tester_addr.as_str()}/{testee_addr.as_str()}/command/"
+    url = net_handler.get_url(base_url, tester_addr.as_str(), other_is_server=True)
+    assert url == expected
+
+    base_url = "http://offchain.test.com"
+    expected = f"{base_url}/v1/{tester_addr.as_str()}/{testee_addr.as_str()}/command/"
+    url = net_handler.get_url(base_url, tester_addr.as_str(), other_is_server=True)
+    assert url == expected
+
+    base_url = "http://offchain.test.com/"
+    expected = f"{base_url}v1/{tester_addr.as_str()}/{testee_addr.as_str()}/command/"
+    url = net_handler.get_url(base_url, tester_addr.as_str(), other_is_server=True)
+    assert url == expected


### PR DESCRIPTION
urljoin strips the path: 

```
urljoin("http://lrw2_backend-web-server_1:5091/offchain", "v1/x/x")
'http://lrw2_backend-web-server_1:5091/v1/x/x'
```

You can see that the path "/offchain" gets removed, which is necessary for correct routing of offchain calls. 

Chang to use os.path.join:
```
os.path.join(“http://lrw2_backend-web-server_1:5091/offchain”, “v1/x/x”)
‘http://lrw2_backend-web-server_1:5091/offchain/v1/x/x’
```

Unit tests pass with the change