### PR TITLE
Remove trailing / on asyncnet

### DIFF
--- a/src/offchainapi/asyncnet.py
+++ b/src/offchainapi/asyncnet.py
@@ -126,7 +126,7 @@ class Aionet:
         else:
             server = self.vasp.get_vasp_address().as_str()
             client = other_addr_str
-        url = f'v1/{server}/{client}/command/'
+        url = f'v1/{server}/{client}/command'
         full_url = '/'.join([base_url.rstrip('/'), url])
         return full_url
 

--- a/src/offchainapi/tests/test_asyncnet.py
+++ b/src/offchainapi/tests/test_asyncnet.py
@@ -142,21 +142,21 @@ async def test_watchdog_task(net_handler, tester_addr, server, command):
 
 def test_get_url(net_handler, tester_addr, testee_addr):
     base_url = "http://offchain.test.com/offchain"
-    expected = f"{base_url}/v1/{tester_addr.as_str()}/{testee_addr.as_str()}/command/"
+    expected = f"{base_url}/v1/{tester_addr.as_str()}/{testee_addr.as_str()}/command"
     url = net_handler.get_url(base_url, tester_addr.as_str(), other_is_server=True)
     assert url == expected
 
     base_url = "http://offchain.test.com/offchain/"
-    expected = f"{base_url}v1/{tester_addr.as_str()}/{testee_addr.as_str()}/command/"
+    expected = f"{base_url}v1/{tester_addr.as_str()}/{testee_addr.as_str()}/command"
     url = net_handler.get_url(base_url, tester_addr.as_str(), other_is_server=True)
     assert url == expected
 
     base_url = "http://offchain.test.com"
-    expected = f"{base_url}/v1/{tester_addr.as_str()}/{testee_addr.as_str()}/command/"
+    expected = f"{base_url}/v1/{tester_addr.as_str()}/{testee_addr.as_str()}/command"
     url = net_handler.get_url(base_url, tester_addr.as_str(), other_is_server=True)
     assert url == expected
 
     base_url = "http://offchain.test.com/"
-    expected = f"{base_url}v1/{tester_addr.as_str()}/{testee_addr.as_str()}/command/"
+    expected = f"{base_url}v1/{tester_addr.as_str()}/{testee_addr.as_str()}/command"
     url = net_handler.get_url(base_url, tester_addr.as_str(), other_is_server=True)
     assert url == expected


### PR DESCRIPTION
## Motivation

Trailing slash is unnecessary and causes issues in compatibility between different networking stacks. Removing "/"

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

tox

## Related PRs

